### PR TITLE
edited the throws clause for getElementAt

### DIFF
--- a/representation_objects.md
+++ b/representation_objects.md
@@ -279,7 +279,7 @@ public class FractionList {
      * Returns the element at the given index in the list of fractions stored by
      * this object.
      *
-     * @throws IndexOutOfBoundsException | 0 < index || index <= getSize()
+     * @throws IndexOutOfBoundsException | index < 0 || getSize() <= index
      */
     public Fraction getElementAt(int index) {
         if (index < 0 || getSize() <= index)


### PR DESCRIPTION
Hello professor, 
I was reviewing the OGP notes and noticed a small error in the specification for the following example in the module for representation objects: 

the previous specification for throws for getElementAt was incorrect and did not match the correctness of the method: 

IndexOutOfBoundsException | 0 < index || index <= getSize()

it was changed to match the source code specification of the class: 
@throws IndexOutOfBoundsException | index < 0 || getSize() <= index
